### PR TITLE
Adding level setting to force only enabled levels to initiate cart abandonment sequences

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -269,4 +269,4 @@ register_activation_hook( PMPROACR_BASE_FILE, 'pmproacr_activation' );
 function pmproacr_deactivation() {	
 	wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
 }
-register_deactivation_hook( PMPROACR_BASE_FILE, 'pmpro_deacpmproacr_deactivationtivation' );
+register_deactivation_hook( PMPROACR_BASE_FILE, 'pmproacr_deactivation' );

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -50,6 +50,15 @@ function pmproacr_cron_process_recovery_attempts() {
 	 */
 	$seconds_until_lost       = (int) apply_filters( 'pmproacr_time_until_lost', DAY_IN_SECONDS * 7 );
 
+	// Get all levels that have abandoned cart recovery enabled.
+	$enabled_levels = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT DISTINCT pmpro_membership_level_id
+			FROM $wpdb->pmpro_membership_levelmeta
+			WHERE meta_key = 'pmproacr_enabled_for_level' AND meta_value = 'yes'"
+		)
+	);
+
 	// Send the first reminder.
 	// Get all token orders older than the current time - seconds_until_reminder_1 but after the last timestamp checked.
 	// To help with performance and to avoid confusing customers, let's limit the "last timestamp checked" to at most $seconds_until_reminder_1 * 4 in the past.
@@ -61,7 +70,7 @@ function pmproacr_cron_process_recovery_attempts() {
 		$wpdb->prepare(
 			"SELECT o.id, o.user_id, o.membership_id, o.total, o.timestamp
 			FROM $wpdb->pmpro_membership_orders o
-			WHERE o.timestamp > %s AND o.timestamp < %s AND o.status = 'token' AND o.total > 0
+			WHERE o.timestamp > %s AND o.timestamp < %s AND o.status = 'token' AND o.total > 0 AND o.membership_id IN(" . implode( ',', $enabled_levels ) . ")
 			ORDER BY o.timestamp ASC",
 			$reminder_1_oldest_datetime,
 			$reminder_1_newest_datetime

--- a/includes/level-settings.php
+++ b/includes/level-settings.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Add options to level settings to enable Abandoned Cart Recovery.
+ *
+ * @since TBD
+ */
+function pmproacr_membership_level_before_content_settings() {
+	$edit_level_id = $_REQUEST['edit'];
+	$enabled = 'yes' === get_pmpro_membership_level_meta( $edit_level_id, 'pmproacr_enabled_for_level', true );
+	$acr_checked = $enabled ? ' checked' : '';
+
+	if ( ! empty( $enabled ) ) {
+		$section_visibility = 'visible';
+		$section_activated  = 'true';
+	} else {
+		$section_visibility = 'hidden';
+		$section_activated  = 'false';
+	}
+?>
+	<div id="pmpro-acr" class="pmpro_section" data-visibility="<?php echo esc_attr( $section_visibility ); ?>" data-activated="<?php echo esc_attr( $section_activated ); ?>">
+		<div class="pmpro_section_toggle">
+			<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
+				<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
+				<?php esc_html_e( 'Abandoned Cart Recovery Settings', 'pmpro-abandoned-cart-recovery' ); ?>
+			</button>
+		</div>
+		<div class="pmpro_section_inside" <?php echo $section_visibility === 'hidden' ? 'style="display: none"' : ''; ?>>
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row" valign="top">
+							<label for="pmproacr_enabled_for_level"><?php esc_html_e( 'Enable Abandoned Cart Recovery', 'pmpro-abandoned-cart-recovery' ); ?></label>
+						</th>
+						<td>
+							<input type="checkbox" id="pmproacr_enabled_for_level" name="pmproacr_enabled_for_level" value="1" <?php echo $acr_checked; ?> />
+							<label for="pmproacr_enabled_for_level"><?php esc_html_e( 'Enable Abandoned Cart Recovery for this level.', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							<p class="description"><?php esc_html_e( 'Check the box to activate abandoned cart recovery for this level. Emails will be sent 1 hour, 1 day, and 1 week after the cart is abandoned. You can customize these emails on the Settings > Email Templates screen.', 'pmpro-abandoned-cart-recovery' ); ?></p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+<?php
+}
+add_action( 'pmpro_membership_level_before_content_settings', 'pmproacr_membership_level_before_content_settings' );
+
+/**
+ * Save the Abandoned Cart Recovery settings for a membership level.
+ *
+ * @since TBD
+ * @param int $save_id The ID of the membership level being saved.
+ * @return void
+ */
+function pmproacr_save_membership_level( $save_id ) {
+	$enabled = empty( $_REQUEST['pmproacr_enabled_for_level'] ) ? 'no' : 'yes';
+
+	update_pmpro_membership_level_meta( $save_id, 'pmproacr_enabled_for_level', $enabled );
+}
+add_action( 'pmpro_save_membership_level', 'pmproacr_save_membership_level' );

--- a/pmpro-abandoned-cart-recovery.php
+++ b/pmpro-abandoned-cart-recovery.php
@@ -21,6 +21,7 @@ require_once( PMPROACR_DIR . '/includes/admin.php' );
 require_once( PMPROACR_DIR . '/includes/crons.php' );
 require_once( PMPROACR_DIR . '/includes/emails.php' );
 require_once( PMPROACR_DIR . '/includes/checkout.php' );
+require_once( PMPROACR_DIR . '/includes/level-settings.php' );
 require_once( PMPROACR_DIR . '/includes/upgradecheck.php' );
 require_once( PMPROACR_DIR . '/classes/class-pmproacr-recovery-attempts-list-table.php' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now only levels with cart abandonment "enabled" will being an abandonment sequence. 

I don't know if we want some kind of "clean up" so that if a level becomes "not enabled" mid-sequence, it stops. We probably don't want to "clear out" all the data, but we could consider to mark these "failed" or something as a final status so emails 2 and 3 don't send or are left hanging on the report without a status update.
