### PR TITLE
Adding suggested privacy policy text and message at checkout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -2,7 +2,7 @@
 
 * [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
 * [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?
 
 <!-- Mark completed items with an [x] -->
 

--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -1,0 +1,70 @@
+<?php
+/** 
+ * Add suggested Privacy Policy language for Paid Memberships Pro - Abandoned Cart Recovery.
+ *
+ * @since TBD
+ */
+function pmproacr_add_privacy_policy_content() {
+	// Check for support.
+	if ( ! function_exists( 'wp_add_privacy_policy_content') ) {
+		return;
+	}
+
+	$content = '';
+	$content .= '<h2>' . __( 'Abandoned Cart Recovery', 'pmpro-abandoned-cart-recovery' ) . '</h2>';
+	$content .= '<p>' . __( "When a user begins membership checkout but does not complete the purchase within a specified time, the cart is considered abandoned.", 'pmpro-abandoned-cart-recovery' ) . '</p>';
+	$content .= '<p>' . __( "An email is sent to the user to complete the purchase via a link provided in the email.", 'pmpro-abandoned-cart-recovery' ) . '</p>';
+	$content .= '<p>' . __( "The user can unsubscribe from abandoned cart emails using the unsubscribe link in the emails.", 'pmpro-abandoned-cart-recovery' ) . '</p>';
+
+	wp_add_privacy_policy_content( 'Paid Memberships Pro - Abandoned Cart Recovery', $content );
+}
+add_action( 'admin_init', 'pmproacr_add_privacy_policy_content' );
+
+/**
+ * Show a message on the Membership Checkout page related to our use of the user's data.
+ *
+ * @since TBD
+ */
+function pmproacr_show_privacy_message() {
+	// Get the checkout level.
+	$checkout_level = pmpro_getLevelAtCheckout();
+
+	// Check if Abandoned Cart Recovery is enabled for this level.
+	$enabled = 'yes' === get_pmpro_membership_level_meta( $checkout_level->id, 'pmproacr_enabled_for_level', true );
+
+	// If a Privacy Policy page is assigned and published, set the message.
+	$pmproacr_privacy_message = '';
+	$privacy_policy_page_id = (int) get_option( 'wp_page_for_privacy_policy' );
+	if ( ! empty( $privacy_policy_page_id ) ) {
+		$privacy_policy_page = get_post( $privacy_policy_page_id );
+		if ( $privacy_policy_page instanceof WP_Post && $privacy_policy_page->post_status === 'publish' && $enabled ) {
+			$pmproacr_privacy_message = printf(
+				/* translators: %s: Privacy Policy page URL */
+				__( '<p>Your personal data will be used to process your order, support your experience throughout this website, and for other purposes described in our <a href="%s" target="_blank">privacy policy</a>.</p>', 'pmpro-abandoned-cart-recovery' ),
+				esc_url( get_permalink( $privacy_policy_page_id ) )
+			);
+		}
+	}
+
+	$allowed_html = array (
+		'a' => array (
+			'class' => array(),
+			'href' => array(),
+			'target' => array(),
+			'title' => array(),
+		),
+		'p' => array(
+			'class' => array(),
+		),
+		'b' => array(
+			'class' => array(),
+		),
+		'em' => array(
+			'class' => array(),
+		),
+		'br' => array(),
+		'strong' => array(),
+	);
+	return apply_filters( 'pmproacr_privacy_message', wp_kses( $pmproacr_privacy_message, $allowed_html ) );
+}
+add_action( 'pmpro_checkout_before_submit_button', 'pmproacr_show_privacy_message' );

--- a/pmpro-abandoned-cart-recovery.php
+++ b/pmpro-abandoned-cart-recovery.php
@@ -24,6 +24,7 @@ require_once( PMPROACR_DIR . '/includes/emails.php' );
 require_once( PMPROACR_DIR . '/includes/checkout.php' );
 require_once( PMPROACR_DIR . '/includes/level-settings.php' );
 require_once( PMPROACR_DIR . '/includes/opt-out.php' );
+require_once( PMPROACR_DIR . '/includes/privacy.php' );
 require_once( PMPROACR_DIR . '/includes/upgradecheck.php' );
 require_once( PMPROACR_DIR . '/classes/class-pmproacr-recovery-attempts-list-table.php' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now including suggested text for the Privacy Policy as well as a message at checkout above the submit button if the level has ARC enabled.

Adds filter: `pmproacr_privacy_message` to change or unset the message.

![Screenshot 2024-11-01 at 2 07 51 PM](https://github.com/user-attachments/assets/b4353d03-5b0c-418e-b8d7-94ae43e4de6f)

![Screenshot 2024-11-01 at 2 33 05 PM](https://github.com/user-attachments/assets/3e528b53-a91c-4ac4-b584-b705fc172b7d)
