### PR TITLE
Do not mark free orders as recovered

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -11,6 +11,12 @@
 function pmproacr_after_checkout( $user_id, $order ) {
 	global $wpdb;
 
+	// If the order was free, don't mark the recovery attempt as recovered.
+	if ( empty( $order->total ) ) {
+		return;
+	}
+
+	// Update the recovery attempt to recovered.
 	$wpdb->update(
 		$wpdb->pmproacr_recovery_attempts,
 		array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Prevents a recovery attempt from becoming `recovered` due to a free checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
