### PR TITLE
[BUGFIXING] Select query to get levels that had pmproacr_enabled_for_level checked need to parameterize the value

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -51,13 +51,12 @@ function pmproacr_cron_process_recovery_attempts() {
 	$seconds_until_lost = (int) apply_filters( 'pmproacr_time_until_lost', DAY_IN_SECONDS * 7 );
 
 
-	$query = $wpdb->prepare(
-		'SELECT DISTINCT pmpro_membership_level_id FROM wp_pmpro_membership_levelmeta
-		 WHERE meta_key = %s AND meta_value = %s',
-		'pmproacr_enabled_for_level',
-		'yes'
-	);
+	// Get all levels that have abandoned cart recovery enabled.
+	$query = "SELECT DISTINCT pmpro_membership_level_id FROM wp_pmpro_membership_levelmeta
+			WHERE meta_key = 'pmproacr_enabled_for_level' AND meta_value = 'yes'";
+
 	$enabled_levels = $wpdb->get_col( $query );
+
 
 	// Send the first reminder.
 	// Get all token orders older than the current time - seconds_until_reminder_1 but after the last timestamp checked.

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -50,13 +50,12 @@ function pmproacr_cron_process_recovery_attempts() {
 	 */
 	$seconds_until_lost = (int) apply_filters( 'pmproacr_time_until_lost', DAY_IN_SECONDS * 7 );
 
-
 	// Get all levels that have abandoned cart recovery enabled.
-	$query = "SELECT DISTINCT pmpro_membership_level_id FROM wp_pmpro_membership_levelmeta
-			WHERE meta_key = 'pmproacr_enabled_for_level' AND meta_value = 'yes'";
-
-	$enabled_levels = $wpdb->get_col( $query );
-
+	$enabled_levels = $wpdb->get_col(
+		"SELECT DISTINCT pmpro_membership_level_id
+		FROM $wpdb->pmpro_membership_levelmeta
+		WHERE meta_key = 'pmproacr_enabled_for_level' AND meta_value = 'yes'"
+	);
 
 	// Send the first reminder.
 	// Get all token orders older than the current time - seconds_until_reminder_1 but after the last timestamp checked.

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -50,14 +50,14 @@ function pmproacr_cron_process_recovery_attempts() {
 	 */
 	$seconds_until_lost = (int) apply_filters( 'pmproacr_time_until_lost', DAY_IN_SECONDS * 7 );
 
-	// Get all levels that have abandoned cart recovery enabled.
-	$enabled_levels = $wpdb->get_col(
-		$wpdb->prepare(
-			"SELECT DISTINCT pmpro_membership_level_id
-			FROM $wpdb->pmpro_membership_levelmeta
-			WHERE meta_key = 'pmproacr_enabled_for_level' AND meta_value = 'yes'"
-		)
+
+	$query = $wpdb->prepare(
+		'SELECT DISTINCT pmpro_membership_level_id FROM wp_pmpro_membership_levelmeta
+		 WHERE meta_key = %s AND meta_value = %s',
+		'pmproacr_enabled_for_level',
+		'yes'
 	);
+	$enabled_levels = $wpdb->get_col( $query );
 
 	// Send the first reminder.
 	// Get all token orders older than the current time - seconds_until_reminder_1 but after the last timestamp checked.


### PR DESCRIPTION


PHP Notice:  Function wpdb::prepare was called <strong>incorrectly</strong>. The query argument of wpdb::prepare() must have a placeholder. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.9.0.)

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/76600641-f104-4e8d-82db-37d1f774a645" />


### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


Add the 'yes' value as a parameter to avoid the notice in the log.


### How to test the changes in this Pull Request:

1. Running the cron manually should be enough to see the notice in the log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
