### PR TITLE
Register report with pmpro_registered_reports

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -36,8 +36,21 @@ function pmproacr_admin_page() {
 	require_once PMPRO_DIR . '/adminpages/admin_footer.php';
 }
 
-global $pmpro_reports;
-$pmpro_reports['pmproacr_results'] = __('Abandoned Cart Recoveries', 'pmpro-abandoned-cart-recovery');
+/**
+ * Register the Abandoned Cart Recovery report.
+ *
+ * @since TBD
+ *
+ * @param array $pmpro_reports The existing PMPro reports.
+ * @return array The modified PMPro reports with the Abandoned Cart Recovery report added.
+ */
+function pmproacr_register_report_pmproacr_results( $pmpro_reports ) {
+	$pmpro_reports['pmproacr_results'] = __( 'Abandoned Cart Recoveries', 'pmpro-abandoned-cart-recovery' );
+
+	return $pmpro_reports;
+}
+add_filter( 'pmpro_registered_reports', 'pmproacr_register_report_pmproacr_results' );
+
 /**
  * Add the Abandoned Cart Recovery report widget to the reports page.
  *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now using the `pmpro_registered_reports` filter to register the Abandoned Cart Recoveries report.

Resolves this warning:
`Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the pmpro-abandoned-cart-recovery domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.7.0.) in ...`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
