### PR TITLE
Avoiding fatal errors when we don't have a user or level.

### DIFF
--- a/includes/emails.php
+++ b/includes/emails.php
@@ -74,6 +74,12 @@ function pmproacr_send_reminder_email( $recovery_attempt, $reminder_number ) {
 	$user  = get_userdata( $recovery_attempt->user_id );
 	$level = pmpro_getLevel( $recovery_attempt->token_level_id );
 
+	// If we don't have a user or a level, bail.
+	if ( empty( $user ) || empty( $level ) ) {
+		return;
+	}
+
+	// Send the email.
 	$template_class = 'PMPro_Email_Template_PMProACR_Reminder_' . $reminder_number;
 	if ( class_exists( $template_class ) ) {
 		// Using PMPro v3.4+. Create an instance of the email template class.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes fatal error when a user being recovered is deleted that prevents all other recoveries from progressing.