### PR TITLE
Adding compatibility for PMPro v3.6

### DIFF
--- a/classes/class-pmproacr-recovery-attempts-list-table.php
+++ b/classes/class-pmproacr-recovery-attempts-list-table.php
@@ -392,7 +392,7 @@ class PMProACR_Recovery_Attempts_List_Table extends WP_List_Table {
 		) ) . '</p>';
 		echo '<p>' . esc_html( self::format_date( $datetime ) ) . '</p>';
 		// Show an edit link.
-		echo '<p><a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $order_id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'pmpro-abandoned-cart-recovery' ) . '</a></p>';
+		echo '<p><a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $order_id, 'id' => $order_id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'pmpro-abandoned-cart-recovery' ) . '</a></p>';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #12 

Fixing broken link to view orders when running PMPro v3.6+

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
