### PR TITLE
Move crons to Action Scheduler.

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -302,3 +302,20 @@ function pmproacr_deactivation() {
 	wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
 }
 register_deactivation_hook( PMPROACR_BASE_FILE, 'pmproacr_deactivation' );
+
+
+/**
+ * Integrate with Action Scheduler instead of crons if PMPro version is 3.5+
+ * 
+ * @since TBD
+ */
+function pmproacr_schedule_recovery_attempts_with_action_scheduler() {
+	if ( class_exists( 'PMPro_Recurring_Actions' ) ) {
+		// Remove the crons that may have been set up previously (for older PMPro installs) to avoid duplicate code running.
+		wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
+
+		// Move this to Action scheduler instead.
+		add_action( 'pmpro_schedule_hourly', 'pmproacr_cron_process_recovery_attempts', 98 );			
+	}
+}
+add_action( 'init', 'pmproacr_schedule_recovery_attempts_with_action_scheduler' );

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -281,11 +281,18 @@ function pmproacr_cron_process_recovery_attempts() {
 add_action( 'pmproacr_cron_process_recovery_attempts', 'pmproacr_cron_process_recovery_attempts' );
 
 /**
- * Schedule the cron job.
+ * Schedule the WP-cron job for sites running PMPro <3.5.
+ *
+ * On PMPro 3.5+ the recovery sweep runs via Action Scheduler instead, so we
+ * skip scheduling a WP-cron event entirely.
  *
  * @since 0.1
  */
 function pmproacr_activation() {
+	if ( class_exists( 'PMPro_Recurring_Actions' ) ) {
+		return;
+	}
+
 	$next = wp_next_scheduled( 'pmproacr_cron_process_recovery_attempts' );
 	if ( ! $next ) {
 		wp_schedule_event( time(), 'hourly', 'pmproacr_cron_process_recovery_attempts' );
@@ -305,21 +312,21 @@ register_deactivation_hook( PMPROACR_BASE_FILE, 'pmproacr_deactivation' );
 
 
 /**
- * Integrate with Action Scheduler instead of crons if PMPro version is 3.5+
- * 
+ * Integrate with Action Scheduler instead of WP-cron when PMPro 3.5+ is active.
+ *
  * @since TBD
  */
 function pmproacr_schedule_recovery_attempts_with_action_scheduler() {
-	if ( class_exists( 'PMPro_Recurring_Actions' ) ) {
-		// Remove the crons that may have been set up previously (for older PMPro installs) to avoid duplicate code running.
-		$has_migrated = get_option( 'pmproacr_migrated_to_action_scheduler', false );
-		if ( ! $has_migrated ) {
-			wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
-			update_option( 'pmproacr_migrated_to_action_scheduler', 1 );
-		}
-
-		// Move this to Action scheduler instead.
-		add_action( 'pmpro_schedule_hourly', 'pmproacr_cron_process_recovery_attempts', 98 );			
+	if ( ! class_exists( 'PMPro_Recurring_Actions' ) ) {
+		return;
 	}
+
+	// Clear any legacy WP-cron event from a pre-3.5 install. Idempotent.
+	wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
+
+	// Run the recovery sweep on PMPro's hourly Action Scheduler hook. Use a late priority
+	// so lighter callbacks on the same hook run first within the Action Scheduler batch
+	// (matches the pattern used by other PMPro email-sending recurring callbacks).
+	add_action( 'pmpro_schedule_hourly', 'pmproacr_cron_process_recovery_attempts', 98 );
 }
 add_action( 'init', 'pmproacr_schedule_recovery_attempts_with_action_scheduler' );

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -312,7 +312,11 @@ register_deactivation_hook( PMPROACR_BASE_FILE, 'pmproacr_deactivation' );
 function pmproacr_schedule_recovery_attempts_with_action_scheduler() {
 	if ( class_exists( 'PMPro_Recurring_Actions' ) ) {
 		// Remove the crons that may have been set up previously (for older PMPro installs) to avoid duplicate code running.
-		wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
+		$has_migrated = get_option( 'pmproacr_migrated_to_action_scheduler', false );
+		if ( ! $has_migrated ) {
+			wp_clear_scheduled_hook( 'pmproacr_cron_process_recovery_attempts' );
+			update_option( 'pmproacr_migrated_to_action_scheduler', 1 );
+		}
 
 		// Move this to Action scheduler instead.
 		add_action( 'pmpro_schedule_hourly', 'pmproacr_cron_process_recovery_attempts', 98 );			


### PR DESCRIPTION
### Changelog entry
* ENHANCEMENT: Move over to Action Scheduler for email reminders. This still supports backwards compatibility for sites that may not have Action Scheduler running.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?


### How to test the changes in this Pull Request:

1. Apply this PR to an existing site.
2. Check out for a paid membership level and bail the checkout so a token order is created.
3. Once the token order exists you can wait for the next hourly action schedule to run, or to run it sooner you may edit the order from step 2 and adjust the order timestamp to be 2 hours before. Then you can run Action Scheduler event `pmpro_schedule_hourly` manually and this information should be logged under Memberships > Abandoned Carts (table).
5. Confirm that the cron job no longer exists using a plugin like WP Crontrol.

You may also test this "naturally". Bail checkout, wait a physical hour and ensure the email is received. There could be a delay due to timing of when the last Action Schedule event ran and the time of checkout but it should be no more than 2 hours. This would only affect the first email reminder, which I think is okay as it's still within an acceptable recovery chance.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
