### PR TITLE
Fix email variables not replaced in test emails

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-1.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-1.php
@@ -164,19 +164,27 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 	 * @return array The arguments to send the test email from the abstract class.
 	 */
 	public static function get_test_email_constructor_args() {
-		global $current_user;
-		$test_user = $current_user;
+		$test_user = wp_get_current_user();
+
+		// If no user is found, create a placeholder user for the test email.
+		if ( empty( $test_user ) || ! ( $test_user instanceof WP_User ) ) {
+			$test_user              = new WP_User( 0 );
+			$test_user->user_login  = 'test_user';
+			$test_user->user_email  = get_option( 'admin_email' );
+			$test_user->display_name = __( 'Test User', 'pmpro-abandoned-cart-recovery' );
+		}
+
 		$all_levels = pmpro_getAllLevels( true );
-		if ( !empty( $all_levels ) ) {
-			$test_user->membership_level = array_pop( $all_levels );
+		if ( ! empty( $all_levels ) ) {
+			$test_membership_level = array_pop( $all_levels );
 		} else {
 			// Provide a default membership level object.
-			$default_level = new stdClass();
-			$default_level->id = 0;
-			$default_level->name = __( 'Default Level', 'pmpro-abandoned-cart-recovery' );
-			$test_user->membership_level = $default_level;
+			$test_membership_level        = new stdClass();
+			$test_membership_level->id    = 0;
+			$test_membership_level->name  = __( 'Default Level', 'pmpro-abandoned-cart-recovery' );
 		}
-		return array( $test_user, $test_user->membership_level );
+
+		return array( $test_user, $test_membership_level );
 	}
 }
 

--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-2.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-2.php
@@ -164,19 +164,27 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 	 * @return array The arguments to send the test email from the abstract class.
 	 */
 	public static function get_test_email_constructor_args() {
-		global $current_user;
-		$test_user = $current_user;
+		$test_user = wp_get_current_user();
+
+		// If no user is found, create a placeholder user for the test email.
+		if ( empty( $test_user ) || ! ( $test_user instanceof WP_User ) ) {
+			$test_user              = new WP_User( 0 );
+			$test_user->user_login  = 'test_user';
+			$test_user->user_email  = get_option( 'admin_email' );
+			$test_user->display_name = __( 'Test User', 'pmpro-abandoned-cart-recovery' );
+		}
+
 		$all_levels = pmpro_getAllLevels( true );
 		if ( ! empty( $all_levels ) ) {
-			$test_user->membership_level = array_pop( $all_levels );
+			$test_membership_level = array_pop( $all_levels );
 		} else {
 			// Provide a default membership level object.
-			$default_level = new stdClass();
-			$default_level->id = 1;
-			$default_level->name = __( 'Default Level', 'pmpro-abandoned-cart-recovery' );
-			$test_user->membership_level = $default_level;
+			$test_membership_level        = new stdClass();
+			$test_membership_level->id    = 1;
+			$test_membership_level->name  = __( 'Default Level', 'pmpro-abandoned-cart-recovery' );
 		}
-		return array( $test_user, $test_user->membership_level );
+
+		return array( $test_user, $test_membership_level );
 	}
 }
 

--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-3.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-3.php
@@ -153,19 +153,27 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 	 * @return array The arguments to send the test email from the abstract class.
 	 */
 	public static function get_test_email_constructor_args() {
-		global $current_user;
-		$test_user = $current_user;
+		$test_user = wp_get_current_user();
+
+		// If no user is found, create a placeholder user for the test email.
+		if ( empty( $test_user ) || ! ( $test_user instanceof WP_User ) ) {
+			$test_user              = new WP_User( 0 );
+			$test_user->user_login  = 'test_user';
+			$test_user->user_email  = get_option( 'admin_email' );
+			$test_user->display_name = __( 'Test User', 'pmpro-abandoned-cart-recovery' );
+		}
+
 		$all_levels = pmpro_getAllLevels( true );
 		if ( ! empty( $all_levels ) ) {
-			$test_user->membership_level = array_pop( $all_levels );
+			$test_membership_level = array_pop( $all_levels );
 		} else {
 			// Provide a default membership level object if none exist.
-			$default_level = new stdClass();
-			$default_level->id = 1;
-			$default_level->name = 'Test Level';
-			$test_user->membership_level = $default_level;
+			$test_membership_level        = new stdClass();
+			$test_membership_level->id    = 1;
+			$test_membership_level->name  = __( 'Test Level', 'pmpro-abandoned-cart-recovery' );
 		}
-		return array( $test_user, $test_user->membership_level );
+
+		return array( $test_user, $test_membership_level );
 	}
 }
 


### PR DESCRIPTION
## Description

This PR fixes the bug where email template variables are not being replaced correctly when sending a test email (live emails work fine).

## Root Cause

The `get_test_email_constructor_args()` method in all three reminder email template classes was using `global $current_user` to get the current user. This global may not be populated at the time the static method is called via AJAX, causing all user-related template variables (`!!display_name!!`, `!!user_login!!`, `!!user_email!!`, `!!opt_out_url!!`, etc.) to resolve to empty strings.

## Fix

- Use `wp_get_current_user()` instead of `global $current_user` for reliable user retrieval
- Provide a fallback `WP_User` placeholder when no user is available (so test emails always have valid data)
- Return a standalone membership level object instead of attaching it to the user object, matching the constructor signature
- Apply the same fix to all three reminder templates

## How to Test

1. Go to **Memberships > Email Templates** in WordPress admin
2. Choose any of the Abandoned Cart Recovery email templates
3. Click **Save Template and Send Test Email**
4. Verify that all template variables are replaced with dummy/real data in the received test email

Fixes #5

---

**Files Changed:**
- `classes/email-templates/class-pmpro-email-template-pmproacr-reminder-1.php`
- `classes/email-templates/class-pmpro-email-template-pmproacr-reminder-2.php`
- `classes/email-templates/class-pmpro-email-template-pmproacr-reminder-3.php`