### PR TITLE
Fix test email variable replacement

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-1.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-1.php
@@ -78,20 +78,11 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		// Allowed strings for kses checks below.
-		$allowed_html = array(
-			'a' => array(
-				'href' => array(),
-				'title' => array(),
-			),
-			'p' => array(),
-		);
+		return wp_kses_post( __( '<p>We noticed you started signing up for {{ membership_level_name }} membership but did not complete the checkout process.</p>
 
-		return '<p>' . esc_html__( 'We noticed you started signing up for !!membership_level_name!! membership but did not complete the checkout process.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+<p><a href="{{ checkout_url }}">Click here to complete membership checkout now</a>.</p>
 
-' . wp_kses( __( '<p><a href="!!checkout_url!!">Click here to complete membership checkout now</a>.</p>', 'pmpro-abandoned-cart-recovery' ), $allowed_html ) . '
-
-' . wp_kses( __( '<p>If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of future emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ), $allowed_html );
+<p>If you do not want to receive any more emails about this attempted checkout, <a href="{{ opt_out_url }}">click here to opt out of future emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ) );
 	}
 
 	/**
@@ -126,13 +117,13 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The username of the user.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'paid-memberships-pro' ),
-            '!!opt_out_url!!' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'paid-memberships-pro' ),
+			'{{ display_name }}' => esc_html__( 'The display name of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_login }}' => esc_html__( 'The username of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_email }}' => esc_html__( 'The email address of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ checkout_url }}' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ opt_out_url }}' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'pmpro-abandoned-cart-recovery' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-2.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-2.php
@@ -67,7 +67,7 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html__( "Reminder: Your !!sitename!! membership is waiting.", 'pmpro-abandoned-cart-recovery' );
+		return esc_html__( 'Reminder: Your {{ sitename }} membership is waiting.', 'pmpro-abandoned-cart-recovery' );
 	}
 
 	/**
@@ -78,20 +78,11 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		// Allowed strings for kses checks below.
-		$allowed_html = array(
-			'a' => array(
-				'href' => array(),
-				'title' => array(),
-			),
-			'p' => array(),
-		);
+		return wp_kses_post( __( '<p>It looks like you may have forgotten to complete checkout for the {{ membership_level_name }} membership at {{ sitename }}.</p>
 
-		return '<p>' . esc_html__( 'It looks like you may have forgotten to complete checkout for the !!membership_level_name!! membership at !!sitename!!.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+<p><a href="{{ checkout_url }}">Complete Your Purchase Now</a></p>
 
-<p><a href="!!checkout_url!!">' . esc_html__( 'Complete Your Purchase Now', 'pmpro-abandoned-cart-recovery' ) . '</a></p>
-
-' . wp_kses( __( '<p>If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of these emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ), $allowed_html );
+<p>If you do not want to receive any more emails about this attempted checkout, <a href="{{ opt_out_url }}">click here to opt out of these emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ) );
 	}
 
 	/**
@@ -126,13 +117,13 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The username of the user.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'paid-memberships-pro' ),
-            '!!opt_out_url!!' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'paid-memberships-pro' ),
+			'{{ display_name }}' => esc_html__( 'The display name of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_login }}' => esc_html__( 'The username of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_email }}' => esc_html__( 'The email address of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ checkout_url }}' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ opt_out_url }}' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'pmpro-abandoned-cart-recovery' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-3.php
+++ b/classes/email-templates/class-pmpro-email-template-pmproacr-reminder-3.php
@@ -67,7 +67,7 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return esc_html__( 'Final Reminder: Complete membership checkout at !!sitename!! today.', 'pmpro-abandoned-cart-recovery' );
+		return esc_html__( 'Final Reminder: Complete membership checkout at {{ sitename }} today.', 'pmpro-abandoned-cart-recovery' );
 	}
 
 	/**
@@ -78,9 +78,9 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return '<p>' . esc_html__( 'This is your final reminder to complete your !!membership_level_name!! membership checkout at !!sitename!!.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+		return wp_kses_post( __( '<p>This is your final reminder to complete your {{ membership_level_name }} membership checkout at {{ sitename }}.</p>
 
-<p><a href="!!checkout_url!!">' . esc_html__( 'Complete Your Purchase Now', 'pmpro-abandoned-cart-recovery' ) . '</a></p>';
+<p><a href="{{ checkout_url }}">Complete Your Purchase Now</a></p>', 'pmpro-abandoned-cart-recovery' ) );
 	}
 
 	/**
@@ -115,13 +115,13 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The username of the user.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'paid-memberships-pro' ),
-            '!!opt_out_url!!' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'paid-memberships-pro' ),
+			'{{ display_name }}' => esc_html__( 'The display name of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_login }}' => esc_html__( 'The username of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ user_email }}' => esc_html__( 'The email address of the user.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ checkout_url }}' => esc_html__( 'The URL to the checkout page with the membership level pre-selected.', 'pmpro-abandoned-cart-recovery' ),
+			'{{ opt_out_url }}' => esc_html__( 'The URL the user can click to opt out of future abandoned cart emails.', 'pmpro-abandoned-cart-recovery' ),
 		);
 	}
 

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -27,43 +27,34 @@ add_action( 'init', 'pmproacr_init_email_templates', 8 ); // Priority 8 to ensur
  * @return array The email templates.
  */
 function pmproacr_email_templates( $templates ) {
-	// Allowed strings for kses checks below.
-	$allowed_html = array(
-		'a' => array(
-			'href' => array(),
-			'title' => array(),
-		),
-		'p' => array(),
-	);
-
 	$templates['pmproacr_reminder_1'] = array(
 		'description' => esc_html__( 'Abandoned Cart Recovery - Reminder 1', 'pmpro-abandoned-cart-recovery' ),
 		'subject'     => esc_html__( 'Your membership is waiting.', 'pmpro-abandoned-cart-recovery' ),
-		'body'        => '<p>' . esc_html__( 'We noticed you started signing up for !!membership_level_name!! membership but did not complete the checkout process.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+		'body'        => wp_kses_post( __( '<p>We noticed you started signing up for !!membership_level_name!! membership but did not complete the checkout process.</p>
 
-' . wp_kses( __( '<p><a href="!!checkout_url!!">Click here to complete membership checkout now</a>.</p>', 'pmpro-abandoned-cart-recovery' ), $allowed_html ) . '
+<p><a href="!!checkout_url!!">Click here to complete membership checkout now</a>.</p>
 
-<p>' . wp_kses( __( 'If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of future emails</a>.', 'pmpro-abandoned-cart-recovery' ), $allowed_html ) . '</p>',
+<p>If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of future emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ) ),
 		'help_text'   => esc_html__( 'This email is sent as the first reminder to complete a purchase.', 'pmpro-abandoned-cart-recovery' )
 	);
 
 	$templates['pmproacr_reminder_2'] = array(
 		'description' => esc_html__( 'Abandoned Cart Recovery - Reminder 2', 'pmpro-abandoned-cart-recovery' ),
 		'subject'     => esc_html__( 'Reminder: Your !!sitename!! membership is waiting.', 'pmpro-abandoned-cart-recovery' ),
-		'body'        => '<p>' . esc_html__( 'It looks like you may have forgotten to complete checkout for the !!membership_level_name!! membership at !!sitename!!.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+		'body'        => wp_kses_post( __( '<p>It looks like you may have forgotten to complete checkout for the !!membership_level_name!! membership at !!sitename!!.</p>
 
-<p><a href="!!checkout_url!!">' . esc_html__( 'Complete Your Purchase Now', 'pmpro-abandoned-cart-recovery' ) . '</a></p>
+<p><a href="!!checkout_url!!">Complete Your Purchase Now</a></p>
 
-<p>' . wp_kses( __( 'If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of these emails</a>.', 'pmpro-abandoned-cart-recovery' ), $allowed_html ) . '</p>',
+<p>If you do not want to receive any more emails about this attempted checkout, <a href="!!opt_out_url!!">click here to opt out of these emails</a>.</p>', 'pmpro-abandoned-cart-recovery' ) ),
 		'help_text'   => esc_html__( 'This email is sent as the second reminder to complete a purchase.', 'pmpro-abandoned-cart-recovery' )
 	);
 
 	$templates['pmproacr_reminder_3'] = array(
 		'description' => esc_html__( 'Abandoned Cart Recovery - Reminder 3', 'pmpro-abandoned-cart-recovery' ),
 		'subject'     => esc_html__( 'Final Reminder: Complete membership checkout at !!sitename!! today.', 'pmpro-abandoned-cart-recovery' ),
-		'body'        => '<p>' . esc_html__( 'This is your final reminder to complete your !!membership_level_name!! membership checkout at !!sitename!!.', 'pmpro-abandoned-cart-recovery' ) . '</p>
+		'body'        => wp_kses_post( __( '<p>This is your final reminder to complete your !!membership_level_name!! membership checkout at !!sitename!!.</p>
 
-<p><a href="!!checkout_url!!">' . esc_html__( 'Complete Your Purchase Now', 'pmpro-abandoned-cart-recovery' ) . '</a></p>',
+<p><a href="!!checkout_url!!">Complete Your Purchase Now</a></p>', 'pmpro-abandoned-cart-recovery' ) ),
 		'help_text'   => esc_html__( 'This email is sent as the third reminder to complete a purchase.', 'pmpro-abandoned-cart-recovery' )
 	);
 


### PR DESCRIPTION
## Summary
- Updates all three reminder email templates to use `{{ variable }}` Liquid template syntax instead of `!!variable!!` legacy syntax, matching how PMPro core email templates work since v3.4+.
- Updates `get_default_body()`, `get_default_subject()`, and `get_email_template_variables_with_description()` in all three reminder classes to use `{{ }}` syntax.
- Fixes the text domain from `paid-memberships-pro` to `pmpro-abandoned-cart-recovery` in the variable description strings.
- Simplifies body sanitization in both class-based and legacy templates using `wp_kses_post()`.

## Details
The email template classes were using `!!variable!!` syntax for default bodies and variable descriptions, while PMPro core's email template system (v3.4+) has moved to `{{ variable }}` Liquid syntax. This mismatch caused test email variables to not be replaced correctly, since the Liquid renderer (used in the test email flow) only processes `{{ }}` tags. Live emails worked because they also ran through the legacy `substitute_variables()` method which handles `!!` syntax.

The legacy `pmproet_templates` filter definitions in `includes/emails.php` retain `!!` syntax since that code path only runs on PMPro < v3.4 which doesn't have the Liquid renderer.

Fixes #5

## Test plan
- [ ] Edit any abandoned cart reminder email template, click "Save Template and Send Email"
- [ ] Verify the test email replaces all variables (`{{ display_name }}`, `{{ checkout_url }}`, `{{ membership_level_name }}`, etc.) with actual values
- [ ] Verify live abandoned cart reminder emails still replace variables correctly
- [ ] Verify the email template editor shows `{{ variable }}` syntax in the variable reference panel, consistent with the global variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)