### PR TITLE
Add Resume Checkout Bar feature

### DIFF
--- a/css/resume-bar.css
+++ b/css/resume-bar.css
@@ -1,15 +1,23 @@
 /**
  * Resume Checkout Bar — popup, sticky bar, and dismiss confirmation styles.
+ *
+ * Everything is scoped under #pmproacr-resume-root so theme buttons (Memberlite, etc.)
+ * can't leak their own backgrounds, colors, font-weights, box-shadows, or hover states
+ * into our modal and bar.
  */
 
-.pmproacr-resume-overlay {
+#pmproacr-resume-root {
+	color-scheme: light;
+}
+
+#pmproacr-resume-root .pmproacr-resume-overlay {
 	position: fixed;
 	inset: 0;
 	background: rgba( 17, 24, 39, 0.55 );
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: 9998;
+	z-index: 99998;
 	padding: 16px;
 	animation: pmproacr-resume-fade-in 180ms ease-out;
 }
@@ -19,7 +27,7 @@
 	to   { opacity: 1; }
 }
 
-.pmproacr-resume-modal {
+#pmproacr-resume-root .pmproacr-resume-modal {
 	background: #ffffff;
 	color: #111827;
 	max-width: 460px;
@@ -36,82 +44,110 @@
 	to   { transform: translateY( 0 )    scale( 1 );    opacity: 1; }
 }
 
-.pmproacr-resume-modal__headline {
+#pmproacr-resume-root .pmproacr-resume-modal__headline {
 	margin: 0 0 12px;
 	font-size: 22px;
 	line-height: 1.25;
 	font-weight: 600;
+	color: #111827;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-.pmproacr-resume-modal__body {
+#pmproacr-resume-root .pmproacr-resume-modal__body {
 	margin: 0 0 22px;
 	font-size: 15px;
 	line-height: 1.5;
 	color: #374151;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-.pmproacr-resume-modal__body a {
-	color: inherit;
+#pmproacr-resume-root .pmproacr-resume-modal__body a {
+	color: #2563eb;
 	text-decoration: underline;
 }
 
-.pmproacr-resume-modal__actions {
+#pmproacr-resume-root .pmproacr-resume-modal__body a:hover,
+#pmproacr-resume-root .pmproacr-resume-modal__body a:focus {
+	color: #1d4ed8;
+	text-decoration: underline;
+}
+
+#pmproacr-resume-root .pmproacr-resume-modal__actions {
 	display: flex;
 	gap: 10px;
 	justify-content: flex-end;
 	flex-wrap: wrap;
 }
 
-.pmproacr-resume-modal__primary,
-.pmproacr-resume-modal__secondary {
-	font: inherit;
+/* Shared button reset — neutralize whatever Memberlite/the active theme applies. */
+#pmproacr-resume-root .pmproacr-resume-modal__primary,
+#pmproacr-resume-root .pmproacr-resume-modal__secondary {
+	-webkit-appearance: none;
+	appearance: none;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.2;
 	padding: 10px 18px;
 	border-radius: 6px;
-	cursor: pointer;
 	border: 1px solid transparent;
-	line-height: 1.2;
+	cursor: pointer;
+	text-shadow: none;
+	box-shadow: none;
+	transition: background-color 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
 }
 
-.pmproacr-resume-modal__primary {
+#pmproacr-resume-root .pmproacr-resume-modal__primary {
 	background: #2563eb;
 	color: #ffffff;
 	border-color: #2563eb;
 }
 
-.pmproacr-resume-modal__primary:hover,
-.pmproacr-resume-modal__primary:focus {
+#pmproacr-resume-root .pmproacr-resume-modal__primary:hover,
+#pmproacr-resume-root .pmproacr-resume-modal__primary:focus,
+#pmproacr-resume-root .pmproacr-resume-modal__primary:active {
 	background: #1d4ed8;
+	color: #ffffff;
 	border-color: #1d4ed8;
+	box-shadow: none;
 }
 
-.pmproacr-resume-modal__primary--danger {
+#pmproacr-resume-root .pmproacr-resume-modal__primary--danger {
 	background: #dc2626;
+	color: #ffffff;
 	border-color: #dc2626;
 }
 
-.pmproacr-resume-modal__primary--danger:hover,
-.pmproacr-resume-modal__primary--danger:focus {
+#pmproacr-resume-root .pmproacr-resume-modal__primary--danger:hover,
+#pmproacr-resume-root .pmproacr-resume-modal__primary--danger:focus,
+#pmproacr-resume-root .pmproacr-resume-modal__primary--danger:active {
 	background: #b91c1c;
+	color: #ffffff;
 	border-color: #b91c1c;
+	box-shadow: none;
 }
 
-.pmproacr-resume-modal__secondary {
-	background: #ffffff;
-	color: #374151;
+#pmproacr-resume-root .pmproacr-resume-modal__secondary {
+	background: #f3f4f6;
+	color: #1f2937;
 	border-color: #d1d5db;
 }
 
-.pmproacr-resume-modal__secondary:hover,
-.pmproacr-resume-modal__secondary:focus {
-	background: #f3f4f6;
+#pmproacr-resume-root .pmproacr-resume-modal__secondary:hover,
+#pmproacr-resume-root .pmproacr-resume-modal__secondary:focus,
+#pmproacr-resume-root .pmproacr-resume-modal__secondary:active {
+	background: #e5e7eb;
+	color: #111827;
+	border-color: #9ca3af;
+	box-shadow: none;
 }
 
-.pmproacr-resume-bar {
+#pmproacr-resume-root .pmproacr-resume-bar {
 	position: fixed;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: 9997;
+	z-index: 99997;
 	background: #111827;
 	color: #ffffff;
 	padding: 12px 16px;
@@ -130,31 +166,43 @@
 	to   { transform: translateY( 0 ); }
 }
 
-.pmproacr-resume-bar__text {
+#pmproacr-resume-root .pmproacr-resume-bar__text {
 	font-size: 15px;
 	line-height: 1.3;
+	color: #ffffff;
 }
 
-.pmproacr-resume-bar__button {
+#pmproacr-resume-root .pmproacr-resume-bar__button {
+	-webkit-appearance: none;
+	appearance: none;
 	background: #f97316;
 	color: #ffffff !important;
 	padding: 8px 18px;
 	border-radius: 6px;
 	font-weight: 600;
-	text-decoration: none !important;
 	font-size: 15px;
 	line-height: 1.2;
 	border: 1px solid #f97316;
+	text-decoration: none !important;
+	text-shadow: none;
+	box-shadow: none;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	transition: background-color 120ms ease-out, border-color 120ms ease-out;
 }
 
-.pmproacr-resume-bar__button:hover,
-.pmproacr-resume-bar__button:focus {
+#pmproacr-resume-root .pmproacr-resume-bar__button:hover,
+#pmproacr-resume-root .pmproacr-resume-bar__button:focus,
+#pmproacr-resume-root .pmproacr-resume-bar__button:active {
 	background: #ea580c;
-	border-color: #ea580c;
 	color: #ffffff !important;
+	border-color: #ea580c;
+	box-shadow: none;
+	text-decoration: none !important;
 }
 
-.pmproacr-resume-bar__close {
+#pmproacr-resume-root .pmproacr-resume-bar__close {
+	-webkit-appearance: none;
+	appearance: none;
 	background: transparent;
 	color: #ffffff;
 	border: 1px solid rgba( 255, 255, 255, 0.4 );
@@ -168,12 +216,20 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	font-weight: 400;
+	box-shadow: none;
+	text-shadow: none;
+	transition: background-color 120ms ease-out, border-color 120ms ease-out;
 }
 
-.pmproacr-resume-bar__close:hover,
-.pmproacr-resume-bar__close:focus {
+#pmproacr-resume-root .pmproacr-resume-bar__close:hover,
+#pmproacr-resume-root .pmproacr-resume-bar__close:focus,
+#pmproacr-resume-root .pmproacr-resume-bar__close:active {
 	background: rgba( 255, 255, 255, 0.12 );
+	color: #ffffff;
 	border-color: rgba( 255, 255, 255, 0.7 );
+	box-shadow: none;
 }
 
 body.has-pmproacr-resume-bar {
@@ -181,18 +237,18 @@ body.has-pmproacr-resume-bar {
 }
 
 @media ( max-width: 480px ) {
-	.pmproacr-resume-bar {
+	#pmproacr-resume-root .pmproacr-resume-bar {
 		padding: 10px 12px;
 		gap: 10px;
 	}
-	.pmproacr-resume-bar__text {
+	#pmproacr-resume-root .pmproacr-resume-bar__text {
 		flex: 1 1 100%;
 		text-align: center;
 	}
-	.pmproacr-resume-modal {
+	#pmproacr-resume-root .pmproacr-resume-modal {
 		padding: 22px 20px 18px;
 	}
-	.pmproacr-resume-modal__headline {
+	#pmproacr-resume-root .pmproacr-resume-modal__headline {
 		font-size: 20px;
 	}
 }

--- a/css/resume-bar.css
+++ b/css/resume-bar.css
@@ -1,0 +1,198 @@
+/**
+ * Resume Checkout Bar — popup, sticky bar, and dismiss confirmation styles.
+ */
+
+.pmproacr-resume-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba( 17, 24, 39, 0.55 );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 9998;
+	padding: 16px;
+	animation: pmproacr-resume-fade-in 180ms ease-out;
+}
+
+@keyframes pmproacr-resume-fade-in {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
+.pmproacr-resume-modal {
+	background: #ffffff;
+	color: #111827;
+	max-width: 460px;
+	width: 100%;
+	border-radius: 10px;
+	padding: 28px 28px 24px;
+	box-shadow: 0 20px 60px rgba( 0, 0, 0, 0.35 );
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	animation: pmproacr-resume-pop-in 220ms cubic-bezier( 0.2, 0.8, 0.2, 1 );
+}
+
+@keyframes pmproacr-resume-pop-in {
+	from { transform: translateY( 10px ) scale( 0.97 ); opacity: 0; }
+	to   { transform: translateY( 0 )    scale( 1 );    opacity: 1; }
+}
+
+.pmproacr-resume-modal__headline {
+	margin: 0 0 12px;
+	font-size: 22px;
+	line-height: 1.25;
+	font-weight: 600;
+}
+
+.pmproacr-resume-modal__body {
+	margin: 0 0 22px;
+	font-size: 15px;
+	line-height: 1.5;
+	color: #374151;
+}
+
+.pmproacr-resume-modal__body a {
+	color: inherit;
+	text-decoration: underline;
+}
+
+.pmproacr-resume-modal__actions {
+	display: flex;
+	gap: 10px;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+}
+
+.pmproacr-resume-modal__primary,
+.pmproacr-resume-modal__secondary {
+	font: inherit;
+	padding: 10px 18px;
+	border-radius: 6px;
+	cursor: pointer;
+	border: 1px solid transparent;
+	line-height: 1.2;
+}
+
+.pmproacr-resume-modal__primary {
+	background: #2563eb;
+	color: #ffffff;
+	border-color: #2563eb;
+}
+
+.pmproacr-resume-modal__primary:hover,
+.pmproacr-resume-modal__primary:focus {
+	background: #1d4ed8;
+	border-color: #1d4ed8;
+}
+
+.pmproacr-resume-modal__primary--danger {
+	background: #dc2626;
+	border-color: #dc2626;
+}
+
+.pmproacr-resume-modal__primary--danger:hover,
+.pmproacr-resume-modal__primary--danger:focus {
+	background: #b91c1c;
+	border-color: #b91c1c;
+}
+
+.pmproacr-resume-modal__secondary {
+	background: #ffffff;
+	color: #374151;
+	border-color: #d1d5db;
+}
+
+.pmproacr-resume-modal__secondary:hover,
+.pmproacr-resume-modal__secondary:focus {
+	background: #f3f4f6;
+}
+
+.pmproacr-resume-bar {
+	position: fixed;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 9997;
+	background: #111827;
+	color: #ffffff;
+	padding: 12px 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 14px;
+	flex-wrap: wrap;
+	box-shadow: 0 -8px 24px rgba( 0, 0, 0, 0.2 );
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+	animation: pmproacr-resume-slide-up 220ms ease-out;
+}
+
+@keyframes pmproacr-resume-slide-up {
+	from { transform: translateY( 100% ); }
+	to   { transform: translateY( 0 ); }
+}
+
+.pmproacr-resume-bar__text {
+	font-size: 15px;
+	line-height: 1.3;
+}
+
+.pmproacr-resume-bar__button {
+	background: #f97316;
+	color: #ffffff !important;
+	padding: 8px 18px;
+	border-radius: 6px;
+	font-weight: 600;
+	text-decoration: none !important;
+	font-size: 15px;
+	line-height: 1.2;
+	border: 1px solid #f97316;
+}
+
+.pmproacr-resume-bar__button:hover,
+.pmproacr-resume-bar__button:focus {
+	background: #ea580c;
+	border-color: #ea580c;
+	color: #ffffff !important;
+}
+
+.pmproacr-resume-bar__close {
+	background: transparent;
+	color: #ffffff;
+	border: 1px solid rgba( 255, 255, 255, 0.4 );
+	border-radius: 50%;
+	width: 28px;
+	height: 28px;
+	font-size: 18px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.pmproacr-resume-bar__close:hover,
+.pmproacr-resume-bar__close:focus {
+	background: rgba( 255, 255, 255, 0.12 );
+	border-color: rgba( 255, 255, 255, 0.7 );
+}
+
+body.has-pmproacr-resume-bar {
+	/* Themes that pin content to the bottom can hook this class to add padding. */
+}
+
+@media ( max-width: 480px ) {
+	.pmproacr-resume-bar {
+		padding: 10px 12px;
+		gap: 10px;
+	}
+	.pmproacr-resume-bar__text {
+		flex: 1 1 100%;
+		text-align: center;
+	}
+	.pmproacr-resume-modal {
+		padding: 22px 20px 18px;
+	}
+	.pmproacr-resume-modal__headline {
+		font-size: 20px;
+	}
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -32,6 +32,7 @@ function pmproacr_admin_page() {
 	?>
 	<h1><?php esc_html_e( 'Abandoned Cart Recovery', 'pmpro-abandoned-cart-recovery' ); ?></h1>
 	<?php
+	pmproacr_resume_render_settings_section();
 	$recovery_attempts_list_table->display();
 	require_once PMPRO_DIR . '/adminpages/admin_footer.php';
 }

--- a/includes/resume-bar-render.php
+++ b/includes/resume-bar-render.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Resume Checkout Bar — front-end render + asset enqueue.
+ *
+ * @since TBD
+ * @package pmpro-abandoned-cart-recovery
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Build the resume URL with level, discount, and payment plan params.
+ *
+ * @since TBD
+ * @param array $cart Saved cart payload.
+ * @return string
+ */
+function pmproacr_resume_build_url( $cart ) {
+	if ( empty( $cart['level_id'] ) || ! function_exists( 'pmpro_url' ) ) {
+		return '';
+	}
+
+	$args = array( 'pmpro_level' => (int) $cart['level_id'] );
+	if ( ! empty( $cart['discount_code'] ) ) {
+		$args['pmpro_discount_code'] = $cart['discount_code'];
+	}
+	if ( ! empty( $cart['payment_plan'] ) ) {
+		$args['pmpropp_chosen_plan'] = $cart['payment_plan'];
+	}
+
+	return add_query_arg( $args, pmpro_url( 'checkout' ) );
+}
+
+/**
+ * Should the Resume Checkout Bar render on the current request?
+ *
+ * @since TBD
+ * @return bool
+ */
+function pmproacr_resume_should_render() {
+	if ( is_admin() || wp_doing_ajax() ) {
+		return false;
+	}
+
+	$settings = pmproacr_resume_get_settings();
+	if ( empty( $settings['enabled'] ) ) {
+		return false;
+	}
+
+	if ( ! function_exists( 'pmpro_is_checkout' ) ) {
+		return false;
+	}
+
+	// Don't show on the checkout page itself.
+	if ( pmpro_is_checkout() ) {
+		return false;
+	}
+
+	$cart = pmproacr_resume_get_saved_cart();
+	if ( empty( $cart['level_id'] ) ) {
+		return false;
+	}
+
+	/**
+	 * Filter whether the Resume Checkout Bar should render on the current request.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool  $should Whether the bar should render.
+	 * @param array $cart   The saved cart payload.
+	 */
+	return (bool) apply_filters( 'pmproacr_resume_should_render', true, $cart );
+}
+
+/**
+ * Enqueue the Resume Checkout Bar assets when the bar should render.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_enqueue_assets() {
+	if ( ! pmproacr_resume_should_render() ) {
+		return;
+	}
+
+	$cart     = pmproacr_resume_get_saved_cart();
+	$settings = pmproacr_resume_get_settings();
+	$base_url = plugins_url( '', PMPROACR_BASE_FILE );
+
+	wp_enqueue_style(
+		'pmproacr-resume-bar',
+		$base_url . '/css/resume-bar.css',
+		array(),
+		PMPROACR_VERSION
+	);
+
+	wp_enqueue_script(
+		'pmproacr-resume-bar',
+		$base_url . '/js/resume-bar.js',
+		array(),
+		PMPROACR_VERSION,
+		true
+	);
+
+	wp_localize_script(
+		'pmproacr-resume-bar',
+		'pmproacrResume',
+		array(
+			'ajaxUrl'         => admin_url( 'admin-ajax.php' ),
+			'nonce'           => wp_create_nonce( 'pmproacr_resume' ),
+			'resumeUrl'       => pmproacr_resume_build_url( $cart ),
+			'cartToken'       => isset( $cart['token'] ) ? $cart['token'] : '',
+			'popupHeadline'   => $settings['popup_headline'],
+			'popupBody'       => $settings['popup_body'],
+			'barText'         => $settings['bar_text'],
+			'barButtonLabel'  => $settings['bar_button_label'],
+			'gotItLabel'      => __( 'Got it', 'pmpro-abandoned-cart-recovery' ),
+			'dismissLabel'    => __( 'Dismiss', 'pmpro-abandoned-cart-recovery' ),
+			'confirmHeadline' => __( 'Hide the Resume Checkout bar?', 'pmpro-abandoned-cart-recovery' ),
+			'confirmBody'     => sprintf(
+				/* translators: %s: URL to the Membership Levels page. */
+				__( 'You can always pick up where you left off from our <a href="%s">Membership Levels</a> page.', 'pmpro-abandoned-cart-recovery' ),
+				esc_url( function_exists( 'pmpro_url' ) ? pmpro_url( 'levels' ) : home_url( '/levels/' ) )
+			),
+			'confirmCancel'   => __( 'Cancel', 'pmpro-abandoned-cart-recovery' ),
+			'confirmConfirm'  => __( 'Hide', 'pmpro-abandoned-cart-recovery' ),
+			'closeLabel'      => __( 'Close', 'pmpro-abandoned-cart-recovery' ),
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'pmproacr_resume_enqueue_assets' );
+
+/**
+ * Render the Resume Checkout Bar markup into the page footer.
+ *
+ * Markup starts hidden; the JS reveals popup or bar based on sessionStorage state.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_render_markup() {
+	if ( ! pmproacr_resume_should_render() ) {
+		return;
+	}
+	?>
+	<div id="pmproacr-resume-root" aria-live="polite"></div>
+	<?php
+}
+add_action( 'wp_footer', 'pmproacr_resume_render_markup' );

--- a/includes/resume-bar-save.php
+++ b/includes/resume-bar-save.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Resume Checkout Bar — capture cart info on checkout page load, hydrate for logged-in users,
+ * and clear the saved cart on a successful checkout.
+ *
+ * Cart payload is stored in:
+ *   - Cookie  : pmproacr_resume_cart (JSON, TTL from settings)
+ *   - User meta: pmproacr_resume_cart (logged-in users, for cross-device persistence)
+ *
+ * @since TBD
+ * @package pmpro-abandoned-cart-recovery
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'PMPROACR_RESUME_COOKIE' ) ) {
+	define( 'PMPROACR_RESUME_COOKIE', 'pmproacr_resume_cart' );
+}
+if ( ! defined( 'PMPROACR_RESUME_DISMISS_COOKIE' ) ) {
+	define( 'PMPROACR_RESUME_DISMISS_COOKIE', 'pmproacr_resume_dismissed' );
+}
+
+/**
+ * Read the saved cart payload for the current visitor.
+ *
+ * Prefers user meta for logged-in users (so the cart survives device/cookie loss), then
+ * falls back to the cookie. Returns an empty array when there is no saved cart.
+ *
+ * @since TBD
+ * @return array
+ */
+function pmproacr_resume_get_saved_cart() {
+	$cart = array();
+
+	if ( is_user_logged_in() ) {
+		$meta = get_user_meta( get_current_user_id(), 'pmproacr_resume_cart', true );
+		if ( is_array( $meta ) && ! empty( $meta['level_id'] ) ) {
+			$cart = $meta;
+		}
+	}
+
+	if ( empty( $cart ) && ! empty( $_COOKIE[ PMPROACR_RESUME_COOKIE ] ) ) {
+		$decoded = json_decode( wp_unslash( $_COOKIE[ PMPROACR_RESUME_COOKIE ] ), true );
+		if ( is_array( $decoded ) && ! empty( $decoded['level_id'] ) ) {
+			$cart = $decoded;
+		}
+	}
+
+	if ( empty( $cart ) ) {
+		return array();
+	}
+
+	// Check TTL — drop the cart if it has aged out beyond the configured window.
+	$settings = pmproacr_resume_get_settings();
+	$ttl      = max( 1, (int) $settings['cart_ttl_days'] ) * DAY_IN_SECONDS;
+	if ( empty( $cart['saved_at'] ) || ( time() - (int) $cart['saved_at'] ) > $ttl ) {
+		pmproacr_resume_clear_cart();
+		return array();
+	}
+
+	return $cart;
+}
+
+/**
+ * Persist a cart payload to the cookie + user meta.
+ *
+ * @since TBD
+ * @param array $cart Cart payload (level_id, discount_code, payment_plan, token, saved_at).
+ * @return void
+ */
+function pmproacr_resume_set_cart( $cart ) {
+	if ( empty( $cart['level_id'] ) ) {
+		return;
+	}
+
+	$settings = pmproacr_resume_get_settings();
+	$ttl      = max( 1, (int) $settings['cart_ttl_days'] ) * DAY_IN_SECONDS;
+	$expires  = time() + $ttl;
+
+	$payload = array(
+		'token'         => ! empty( $cart['token'] ) ? sanitize_text_field( $cart['token'] ) : wp_generate_uuid4(),
+		'level_id'      => (int) $cart['level_id'],
+		'discount_code' => isset( $cart['discount_code'] ) ? preg_replace( '/[^A-Za-z0-9\-]/', '', (string) $cart['discount_code'] ) : '',
+		'payment_plan'  => isset( $cart['payment_plan'] ) ? sanitize_text_field( (string) $cart['payment_plan'] ) : '',
+		'saved_at'      => time(),
+	);
+
+	if ( ! headers_sent() ) {
+		setcookie(
+			PMPROACR_RESUME_COOKIE,
+			wp_json_encode( $payload ),
+			array(
+				'expires'  => $expires,
+				'path'     => COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => is_ssl(),
+				'httponly' => false,
+				'samesite' => 'Lax',
+			)
+		);
+	}
+
+	$_COOKIE[ PMPROACR_RESUME_COOKIE ] = wp_json_encode( $payload );
+
+	if ( is_user_logged_in() ) {
+		update_user_meta( get_current_user_id(), 'pmproacr_resume_cart', $payload );
+	}
+}
+
+/**
+ * Clear the saved cart from both cookie and user meta.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_clear_cart() {
+	if ( ! headers_sent() ) {
+		setcookie(
+			PMPROACR_RESUME_COOKIE,
+			'',
+			array(
+				'expires'  => time() - HOUR_IN_SECONDS,
+				'path'     => COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => is_ssl(),
+				'httponly' => false,
+				'samesite' => 'Lax',
+			)
+		);
+	}
+	unset( $_COOKIE[ PMPROACR_RESUME_COOKIE ] );
+
+	if ( is_user_logged_in() ) {
+		delete_user_meta( get_current_user_id(), 'pmproacr_resume_cart' );
+	}
+}
+
+/**
+ * Capture the current checkout cart when a visitor lands on the checkout page.
+ *
+ * Runs late in wp so $pmpro_level is populated. Reads the same request params PMPro core
+ * already accepts (pmpro_level, pmpro_discount_code, pmpropp_chosen_plan).
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_capture_checkout_cart() {
+	if ( is_admin() || wp_doing_ajax() ) {
+		return;
+	}
+
+	$settings = pmproacr_resume_get_settings();
+	if ( empty( $settings['enabled'] ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'pmpro_is_checkout' ) || ! pmpro_is_checkout() ) {
+		return;
+	}
+
+	global $pmpro_level;
+
+	$level_id = 0;
+	if ( ! empty( $pmpro_level->id ) ) {
+		$level_id = (int) $pmpro_level->id;
+	} elseif ( ! empty( $_REQUEST['pmpro_level'] ) ) {
+		$level_id = (int) $_REQUEST['pmpro_level'];
+	} elseif ( ! empty( $_REQUEST['level'] ) ) {
+		$level_id = (int) $_REQUEST['level'];
+	}
+
+	if ( empty( $level_id ) ) {
+		return;
+	}
+
+	$discount_code = '';
+	if ( ! empty( $_REQUEST['pmpro_discount_code'] ) ) {
+		$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', sanitize_text_field( wp_unslash( $_REQUEST['pmpro_discount_code'] ) ) );
+	} elseif ( ! empty( $_REQUEST['discount_code'] ) ) {
+		$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', sanitize_text_field( wp_unslash( $_REQUEST['discount_code'] ) ) );
+	}
+
+	$payment_plan = '';
+	if ( ! empty( $_REQUEST['pmpropp_chosen_plan'] ) ) {
+		$payment_plan = sanitize_text_field( wp_unslash( $_REQUEST['pmpropp_chosen_plan'] ) );
+	}
+
+	// Preserve the existing token if we already have a saved cart, so dismissal scoping is stable across page loads.
+	$existing = pmproacr_resume_get_saved_cart();
+	$token    = ! empty( $existing['token'] ) && ! empty( $existing['level_id'] ) && (int) $existing['level_id'] === $level_id
+		? $existing['token']
+		: wp_generate_uuid4();
+
+	pmproacr_resume_set_cart( array(
+		'token'         => $token,
+		'level_id'      => $level_id,
+		'discount_code' => $discount_code,
+		'payment_plan'  => $payment_plan,
+	) );
+}
+add_action( 'wp', 'pmproacr_resume_capture_checkout_cart', 99 );
+
+/**
+ * AJAX endpoint for the front-end JS to update the saved cart when discount code or
+ * payment plan changes after page load.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_ajax_update_cart() {
+	check_ajax_referer( 'pmproacr_resume', 'nonce' );
+
+	$settings = pmproacr_resume_get_settings();
+	if ( empty( $settings['enabled'] ) ) {
+		wp_send_json_error( 'disabled' );
+	}
+
+	$level_id = isset( $_POST['level_id'] ) ? (int) $_POST['level_id'] : 0;
+	if ( empty( $level_id ) ) {
+		wp_send_json_error( 'no_level' );
+	}
+
+	$discount_code = isset( $_POST['discount_code'] ) ? preg_replace( '/[^A-Za-z0-9\-]/', '', sanitize_text_field( wp_unslash( $_POST['discount_code'] ) ) ) : '';
+	$payment_plan  = isset( $_POST['payment_plan'] ) ? sanitize_text_field( wp_unslash( $_POST['payment_plan'] ) ) : '';
+
+	$existing = pmproacr_resume_get_saved_cart();
+	$token    = ! empty( $existing['token'] ) && (int) $existing['level_id'] === $level_id ? $existing['token'] : wp_generate_uuid4();
+
+	pmproacr_resume_set_cart( array(
+		'token'         => $token,
+		'level_id'      => $level_id,
+		'discount_code' => $discount_code,
+		'payment_plan'  => $payment_plan,
+	) );
+
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_pmproacr_resume_update_cart', 'pmproacr_resume_ajax_update_cart' );
+add_action( 'wp_ajax_nopriv_pmproacr_resume_update_cart', 'pmproacr_resume_ajax_update_cart' );
+
+/**
+ * On successful checkout, clear the saved cart so the bar doesn't nag a brand-new member.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_clear_on_checkout() {
+	pmproacr_resume_clear_cart();
+}
+add_action( 'pmpro_after_checkout', 'pmproacr_resume_clear_on_checkout', 20 );
+
+/**
+ * When a logged-in visitor lands on the site, hydrate the cookie from their user meta
+ * (handles the cross-device case where they have a saved cart but no cookie locally).
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_hydrate_cookie_for_user() {
+	if ( ! is_user_logged_in() || is_admin() || wp_doing_ajax() ) {
+		return;
+	}
+
+	if ( ! empty( $_COOKIE[ PMPROACR_RESUME_COOKIE ] ) ) {
+		return;
+	}
+
+	$settings = pmproacr_resume_get_settings();
+	if ( empty( $settings['enabled'] ) ) {
+		return;
+	}
+
+	$meta = get_user_meta( get_current_user_id(), 'pmproacr_resume_cart', true );
+	if ( ! is_array( $meta ) || empty( $meta['level_id'] ) ) {
+		return;
+	}
+
+	$ttl = max( 1, (int) $settings['cart_ttl_days'] ) * DAY_IN_SECONDS;
+	if ( empty( $meta['saved_at'] ) || ( time() - (int) $meta['saved_at'] ) > $ttl ) {
+		delete_user_meta( get_current_user_id(), 'pmproacr_resume_cart' );
+		return;
+	}
+
+	pmproacr_resume_set_cart( $meta );
+}
+add_action( 'wp', 'pmproacr_resume_hydrate_cookie_for_user', 5 );

--- a/includes/resume-bar.php
+++ b/includes/resume-bar.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Resume Checkout Bar — settings, defaults, and admin form rendering.
+ *
+ * @since TBD
+ * @package pmpro-abandoned-cart-recovery
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return default copy + behavior for the Resume Checkout Bar.
+ *
+ * @since TBD
+ * @return array
+ */
+function pmproacr_resume_get_defaults() {
+	return array(
+		'enabled'          => 0,
+		'cart_ttl_days'    => 30,
+		'popup_headline'   => __( 'Take your time — we saved your spot.', 'pmpro-abandoned-cart-recovery' ),
+		'popup_body'       => __( "Keep browsing. Whenever you're ready to finish signing up, just tap the Resume Checkout bar at the bottom of the page.", 'pmpro-abandoned-cart-recovery' ),
+		'bar_text'         => __( 'Ready to finish?', 'pmpro-abandoned-cart-recovery' ),
+		'bar_button_label' => __( 'Resume Checkout', 'pmpro-abandoned-cart-recovery' ),
+	);
+}
+
+/**
+ * Get Resume Checkout Bar settings merged with defaults.
+ *
+ * @since TBD
+ * @return array
+ */
+function pmproacr_resume_get_settings() {
+	$saved = get_option( 'pmproacr_resume_settings', array() );
+	if ( ! is_array( $saved ) ) {
+		$saved = array();
+	}
+	return wp_parse_args( $saved, pmproacr_resume_get_defaults() );
+}
+
+/**
+ * Sanitize and save the Resume Checkout Bar settings from $_POST.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_save_settings() {
+	if ( empty( $_POST['pmproacr_resume_save'] ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	check_admin_referer( 'pmproacr_resume_save', 'pmproacr_resume_nonce' );
+
+	$defaults = pmproacr_resume_get_defaults();
+
+	$ttl_raw = isset( $_POST['pmproacr_resume_cart_ttl_days'] ) ? absint( wp_unslash( $_POST['pmproacr_resume_cart_ttl_days'] ) ) : $defaults['cart_ttl_days'];
+	if ( $ttl_raw < 1 ) {
+		$ttl_raw = 1;
+	}
+	if ( $ttl_raw > 365 ) {
+		$ttl_raw = 365;
+	}
+
+	$settings = array(
+		'enabled'          => empty( $_POST['pmproacr_resume_enabled'] ) ? 0 : 1,
+		'cart_ttl_days'    => $ttl_raw,
+		'popup_headline'   => isset( $_POST['pmproacr_resume_popup_headline'] ) ? sanitize_text_field( wp_unslash( $_POST['pmproacr_resume_popup_headline'] ) ) : $defaults['popup_headline'],
+		'popup_body'       => isset( $_POST['pmproacr_resume_popup_body'] ) ? sanitize_textarea_field( wp_unslash( $_POST['pmproacr_resume_popup_body'] ) ) : $defaults['popup_body'],
+		'bar_text'         => isset( $_POST['pmproacr_resume_bar_text'] ) ? sanitize_text_field( wp_unslash( $_POST['pmproacr_resume_bar_text'] ) ) : $defaults['bar_text'],
+		'bar_button_label' => isset( $_POST['pmproacr_resume_bar_button_label'] ) ? sanitize_text_field( wp_unslash( $_POST['pmproacr_resume_bar_button_label'] ) ) : $defaults['bar_button_label'],
+	);
+
+	// Fall back to defaults if a copy field was cleared, so the front-end never renders an empty label.
+	foreach ( array( 'popup_headline', 'popup_body', 'bar_text', 'bar_button_label' ) as $copy_key ) {
+		if ( '' === $settings[ $copy_key ] ) {
+			$settings[ $copy_key ] = $defaults[ $copy_key ];
+		}
+	}
+
+	update_option( 'pmproacr_resume_settings', $settings );
+
+	add_settings_error(
+		'pmproacr_resume',
+		'pmproacr_resume_saved',
+		__( 'Resume Checkout Bar settings saved.', 'pmpro-abandoned-cart-recovery' ),
+		'updated'
+	);
+}
+add_action( 'admin_init', 'pmproacr_resume_save_settings' );
+
+/**
+ * Render the Resume Checkout Bar settings section on the Abandoned Cart Recovery admin page.
+ *
+ * @since TBD
+ * @return void
+ */
+function pmproacr_resume_render_settings_section() {
+	$settings = pmproacr_resume_get_settings();
+	$enabled  = ! empty( $settings['enabled'] );
+
+	settings_errors( 'pmproacr_resume' );
+	?>
+	<div id="pmproacr-resume-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
+		<div class="pmpro_section_toggle">
+			<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+				<span class="dashicons dashicons-arrow-up-alt2"></span>
+				<?php esc_html_e( 'Resume Checkout Bar Settings', 'pmpro-abandoned-cart-recovery' ); ?>
+			</button>
+		</div>
+		<div class="pmpro_section_inside">
+			<p class="description">
+				<?php esc_html_e( 'Save a visitor’s cart (level, discount code, and payment plan) when they reach the checkout page, then show a popup and a sticky bottom bar that links them back to checkout if they leave without completing.', 'pmpro-abandoned-cart-recovery' ); ?>
+			</p>
+			<form method="post" action="">
+				<?php wp_nonce_field( 'pmproacr_resume_save', 'pmproacr_resume_nonce' ); ?>
+				<input type="hidden" name="pmproacr_resume_save" value="1" />
+				<table class="form-table">
+					<tbody>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_enabled"><?php esc_html_e( 'Enable Resume Checkout Bar', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<input type="checkbox" id="pmproacr_resume_enabled" name="pmproacr_resume_enabled" value="1" <?php checked( $enabled ); ?> />
+								<label for="pmproacr_resume_enabled"><?php esc_html_e( 'Show a popup and bottom bar to recover visitors who leave the checkout page before completing.', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_cart_ttl_days"><?php esc_html_e( 'Save cart for', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<input type="number" id="pmproacr_resume_cart_ttl_days" name="pmproacr_resume_cart_ttl_days" value="<?php echo esc_attr( $settings['cart_ttl_days'] ); ?>" min="1" max="365" step="1" class="small-text" />
+								<?php esc_html_e( 'days', 'pmpro-abandoned-cart-recovery' ); ?>
+								<p class="description"><?php esc_html_e( 'How long to remember a saved cart before clearing it. Cleared automatically on a successful checkout.', 'pmpro-abandoned-cart-recovery' ); ?></p>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_popup_headline"><?php esc_html_e( 'Popup Headline', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<input type="text" id="pmproacr_resume_popup_headline" name="pmproacr_resume_popup_headline" value="<?php echo esc_attr( $settings['popup_headline'] ); ?>" class="regular-text" />
+							</td>
+						</tr>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_popup_body"><?php esc_html_e( 'Popup Body', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<textarea id="pmproacr_resume_popup_body" name="pmproacr_resume_popup_body" rows="3" class="large-text"><?php echo esc_textarea( $settings['popup_body'] ); ?></textarea>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_bar_text"><?php esc_html_e( 'Bar Text', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<input type="text" id="pmproacr_resume_bar_text" name="pmproacr_resume_bar_text" value="<?php echo esc_attr( $settings['bar_text'] ); ?>" class="regular-text" />
+							</td>
+						</tr>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="pmproacr_resume_bar_button_label"><?php esc_html_e( 'Bar Button Label', 'pmpro-abandoned-cart-recovery' ); ?></label>
+							</th>
+							<td>
+								<input type="text" id="pmproacr_resume_bar_button_label" name="pmproacr_resume_bar_button_label" value="<?php echo esc_attr( $settings['bar_button_label'] ); ?>" class="regular-text" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<p>
+					<button type="submit" class="button button-primary"><?php esc_html_e( 'Save Resume Bar Settings', 'pmpro-abandoned-cart-recovery' ); ?></button>
+				</p>
+			</form>
+		</div>
+	</div>
+	<?php
+}

--- a/js/resume-bar.js
+++ b/js/resume-bar.js
@@ -1,0 +1,236 @@
+/**
+ * Resume Checkout Bar — front-end controller.
+ *
+ * Renders one of three views into #pmproacr-resume-root based on session state:
+ *   - Popup (first non-checkout page after a saved cart appears)
+ *   - Sticky bottom bar (after popup is dismissed, or popup already shown this session)
+ *   - Dismiss confirmation modal (when the bar's close button is clicked)
+ */
+( function () {
+	'use strict';
+
+	if ( typeof window.pmproacrResume === 'undefined' ) {
+		return;
+	}
+
+	var cfg          = window.pmproacrResume;
+	var POPUP_FLAG   = 'pmproacrResumePopupShown';
+	var DISMISS_FLAG = 'pmproacrResumeDismissed:' + ( cfg.cartToken || 'global' );
+
+	function isDismissedForThisCart() {
+		try {
+			return window.localStorage.getItem( DISMISS_FLAG ) === '1';
+		} catch ( err ) {
+			return document.cookie.indexOf( 'pmproacr_resume_dismissed=' + ( cfg.cartToken || '' ) ) !== -1;
+		}
+	}
+
+	function markDismissedForThisCart() {
+		try {
+			window.localStorage.setItem( DISMISS_FLAG, '1' );
+		} catch ( err ) {
+			document.cookie = 'pmproacr_resume_dismissed=' + ( cfg.cartToken || '' ) + ';path=/;max-age=' + ( 60 * 60 * 24 * 30 );
+		}
+	}
+
+	function popupShownThisSession() {
+		try {
+			return window.sessionStorage.getItem( POPUP_FLAG ) === '1';
+		} catch ( err ) {
+			return false;
+		}
+	}
+
+	function markPopupShown() {
+		try {
+			window.sessionStorage.setItem( POPUP_FLAG, '1' );
+		} catch ( err ) { /* swallow */ }
+	}
+
+	function createEl( tag, attrs, children ) {
+		var el = document.createElement( tag );
+		if ( attrs ) {
+			Object.keys( attrs ).forEach( function ( key ) {
+				if ( key === 'className' ) {
+					el.className = attrs[ key ];
+				} else if ( key === 'html' ) {
+					el.innerHTML = attrs[ key ];
+				} else {
+					el.setAttribute( key, attrs[ key ] );
+				}
+			} );
+		}
+		( children || [] ).forEach( function ( child ) {
+			if ( typeof child === 'string' ) {
+				el.appendChild( document.createTextNode( child ) );
+			} else if ( child ) {
+				el.appendChild( child );
+			}
+		} );
+		return el;
+	}
+
+	function renderBar( root ) {
+		root.innerHTML = '';
+		var bar = createEl( 'div', { className: 'pmproacr-resume-bar', role: 'region', 'aria-label': cfg.barText } );
+
+		var label = createEl( 'span', { className: 'pmproacr-resume-bar__text' }, [ cfg.barText ] );
+
+		var resume = createEl( 'a', {
+			className: 'pmproacr-resume-bar__button',
+			href: cfg.resumeUrl
+		}, [ cfg.barButtonLabel ] );
+
+		var close = createEl( 'button', {
+			type: 'button',
+			className: 'pmproacr-resume-bar__close',
+			'aria-label': cfg.closeLabel
+		} );
+		close.innerHTML = '&times;';
+		close.addEventListener( 'click', function () {
+			renderConfirm( root );
+		} );
+
+		bar.appendChild( label );
+		bar.appendChild( resume );
+		bar.appendChild( close );
+		root.appendChild( bar );
+
+		// Add a body class so themes can pad their footer if needed.
+		document.body.classList.add( 'has-pmproacr-resume-bar' );
+	}
+
+	function renderPopup( root ) {
+		root.innerHTML = '';
+
+		var overlay = createEl( 'div', { className: 'pmproacr-resume-overlay', role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': 'pmproacr-resume-popup-headline' } );
+
+		var modal = createEl( 'div', { className: 'pmproacr-resume-modal' } );
+
+		var headline = createEl( 'h2', {
+			id: 'pmproacr-resume-popup-headline',
+			className: 'pmproacr-resume-modal__headline'
+		}, [ cfg.popupHeadline ] );
+
+		var body = createEl( 'p', { className: 'pmproacr-resume-modal__body' }, [ cfg.popupBody ] );
+
+		var actions = createEl( 'div', { className: 'pmproacr-resume-modal__actions' } );
+
+		var gotIt = createEl( 'button', {
+			type: 'button',
+			className: 'pmproacr-resume-modal__primary'
+		}, [ cfg.gotItLabel ] );
+		gotIt.addEventListener( 'click', function () {
+			markPopupShown();
+			renderBar( root );
+		} );
+
+		var dismiss = createEl( 'button', {
+			type: 'button',
+			className: 'pmproacr-resume-modal__secondary'
+		}, [ cfg.dismissLabel ] );
+		dismiss.addEventListener( 'click', function () {
+			markPopupShown();
+			renderConfirm( root );
+		} );
+
+		actions.appendChild( gotIt );
+		actions.appendChild( dismiss );
+
+		modal.appendChild( headline );
+		modal.appendChild( body );
+		modal.appendChild( actions );
+		overlay.appendChild( modal );
+		root.appendChild( overlay );
+
+		// Clicking outside the modal also moves to the bar (treat as "got it").
+		overlay.addEventListener( 'click', function ( event ) {
+			if ( event.target === overlay ) {
+				markPopupShown();
+				renderBar( root );
+			}
+		} );
+
+		// Esc key = same as clicking outside.
+		document.addEventListener( 'keydown', function escHandler( event ) {
+			if ( event.key === 'Escape' ) {
+				document.removeEventListener( 'keydown', escHandler );
+				markPopupShown();
+				renderBar( root );
+			}
+		} );
+	}
+
+	function renderConfirm( root ) {
+		root.innerHTML = '';
+
+		var overlay = createEl( 'div', { className: 'pmproacr-resume-overlay', role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': 'pmproacr-resume-confirm-headline' } );
+
+		var modal = createEl( 'div', { className: 'pmproacr-resume-modal' } );
+
+		var headline = createEl( 'h2', {
+			id: 'pmproacr-resume-confirm-headline',
+			className: 'pmproacr-resume-modal__headline'
+		}, [ cfg.confirmHeadline ] );
+
+		var body = createEl( 'p', { className: 'pmproacr-resume-modal__body', html: cfg.confirmBody } );
+
+		var actions = createEl( 'div', { className: 'pmproacr-resume-modal__actions' } );
+
+		var cancel = createEl( 'button', {
+			type: 'button',
+			className: 'pmproacr-resume-modal__secondary'
+		}, [ cfg.confirmCancel ] );
+		cancel.addEventListener( 'click', function () {
+			renderBar( root );
+		} );
+
+		var confirm = createEl( 'button', {
+			type: 'button',
+			className: 'pmproacr-resume-modal__primary pmproacr-resume-modal__primary--danger'
+		}, [ cfg.confirmConfirm ] );
+		confirm.addEventListener( 'click', function () {
+			markDismissedForThisCart();
+			root.innerHTML = '';
+			document.body.classList.remove( 'has-pmproacr-resume-bar' );
+		} );
+
+		actions.appendChild( cancel );
+		actions.appendChild( confirm );
+
+		modal.appendChild( headline );
+		modal.appendChild( body );
+		modal.appendChild( actions );
+		overlay.appendChild( modal );
+		root.appendChild( overlay );
+
+		overlay.addEventListener( 'click', function ( event ) {
+			if ( event.target === overlay ) {
+				renderBar( root );
+			}
+		} );
+	}
+
+	function init() {
+		var root = document.getElementById( 'pmproacr-resume-root' );
+		if ( ! root || ! cfg.resumeUrl ) {
+			return;
+		}
+
+		if ( isDismissedForThisCart() ) {
+			return;
+		}
+
+		if ( popupShownThisSession() ) {
+			renderBar( root );
+		} else {
+			renderPopup( root );
+		}
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/pmpro-abandoned-cart-recovery.php
+++ b/pmpro-abandoned-cart-recovery.php
@@ -26,6 +26,9 @@ require_once( PMPROACR_DIR . '/includes/level-settings.php' );
 require_once( PMPROACR_DIR . '/includes/opt-out.php' );
 require_once( PMPROACR_DIR . '/includes/privacy.php' );
 require_once( PMPROACR_DIR . '/includes/upgradecheck.php' );
+require_once( PMPROACR_DIR . '/includes/resume-bar.php' );
+require_once( PMPROACR_DIR . '/includes/resume-bar-save.php' );
+require_once( PMPROACR_DIR . '/includes/resume-bar-render.php' );
 require_once( PMPROACR_DIR . '/classes/class-pmproacr-recovery-attempts-list-table.php' );
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,7 @@ The Abandoned Cart Recovery Add On helps maximize your membership site's revenue
 * Fully customizable email templates for each reminder with opt-out options.
 * Detailed reporting of recovery attempts, recovered orders, and recovered revenue.
 * Privacy-focused integration with your site's existing privacy policy.
+* Optional Resume Checkout Bar: capture the visitor's cart on the checkout page and show a popup plus sticky bottom bar on other pages that links them back to checkout with their level, discount code, and payment plan pre-applied.
 
 == Installation ==
 
@@ -31,6 +32,9 @@ The Abandoned Cart Recovery Add On helps maximize your membership site's revenue
 Please post it in the issues section of GitHub and we'll fix it as soon as we can. Thanks for helping. https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/issues
 
 == Changelog ==
+= TBD =
+* FEATURE: New "Resume Checkout Bar". When enabled, captures level/discount/payment plan when a visitor reaches the checkout page, then shows a popup and sticky bottom bar on subsequent pages linking back to checkout with everything pre-filled. Saved to cookie + user meta. Cleared on successful checkout. Settings live on Memberships > Abandoned Cart Recovery.
+
 = 1.0.3 - 2026-05-01 =
 * ENHANCEMENT: Recovery reminder emails are now scheduled via Action Scheduler when running PMPro 3.5 or newer. Sites on older versions continue to use WP-Cron. #17 (@andrewlimaza)
 * ENHANCEMENT: Updated the default subject and body for the three recovery reminder email templates to use Liquid (`{{ variable }}`) syntax on PMPro 3.7 and newer. Older PMPro versions continue to receive the legacy `!!variable!!` defaults. #18 (@dparker1005)


### PR DESCRIPTION
## Summary

Adds an opt-in **Resume Checkout Bar** to the Abandoned Cart Recovery Add On. Complements the existing email recovery flow — the emails handle "got a payment token but never paid"; this handles "loaded the checkout page and bailed before submitting."

When a visitor reaches the checkout page, we capture their cart (level, discount code, payment plan) into a cookie and — if logged in — user meta. On the first subsequent non-checkout page in the session, a centered popup invites them back. "Got it" or click-away minimizes it to a sticky bottom bar that persists across pages. Click the bar's resume button → back to checkout with everything pre-applied. Click the X → styled confirmation modal → bar dismissed for that cart token.

The whole feature is gated on a new setting (off by default), and the saved cart is cleared automatically on `pmpro_after_checkout`.

## What's new

- **Settings section** on *Memberships → Abandoned Cart Recovery*: enable toggle, cart TTL (default 30 days), and overridable copy for the popup headline/body, bar text, and resume button label.
- **Cart capture** on any page detected by `pmpro_is_checkout()` (canonical page or shortcode/block). Stores level from `$pmpro_level->id`, discount code from `pmpro_discount_code`/`discount_code`, and payment plan from `pmpropp_chosen_plan`. AJAX endpoint (`pmproacr_resume_update_cart`) is available for JS to re-sync if discount/plan change after page load.
- **Cookie + user meta** persistence keyed on a UUID `token` for stable dismissal scoping. TTL-aware on read; logged-in user meta wins over cookie so a logged-in member with a saved cart still sees the bar across devices.
- **Front-end** renders into a single `#pmproacr-resume-root` div in `wp_footer`. Vanilla JS (no jQuery dependency) handles popup → bar → confirm-modal state. `sessionStorage` flag controls "popup shown this session"; `localStorage` flag (cart-token-scoped) controls "user dismissed this cart."
- **Filter hook**: `pmproacr_resume_should_render` to allow themes/sites to suppress the bar conditionally.

## What's NOT changed

- Existing recovery-attempts table, level meta, email templates, and cron logic are untouched.
- No new DB schema. Settings live in a single `pmproacr_resume_settings` option; cart payload lives in a cookie + user meta.

## Files

```
includes/resume-bar.php         (settings + defaults + admin form)
includes/resume-bar-save.php    (cart capture / hydrate / clear)
includes/resume-bar-render.php  (front-end enqueue + footer root div)
js/resume-bar.js                (popup / bar / dismiss controller)
css/resume-bar.css              (modal + sticky bar styles)
```

Wire-up: three `require_once` lines added to `pmpro-abandoned-cart-recovery.php`, one call to the settings renderer added inside the existing `pmproacr_admin_page()`.

## Test plan

- [x] Visit checkout with `?pmpro_level=2` → cookie written with level, token, saved_at
- [x] Visit checkout with `?pmpro_level=2&pmpro_discount_code=AFFILIATE10&pmpropp_chosen_plan=99` → cookie captures all three fields
- [x] Navigate to homepage → `#pmproacr-resume-root` rendered, JS+CSS enqueued, `resumeUrl` contains all three params
- [x] Visit checkout page itself with a saved cart → bar does NOT render (correct: don't nag on the page they're already on)
- [x] Disable in settings → no markup or assets emitted even with a valid cookie
- [x] Stale cart (saved_at older than TTL) → cleared on read
- [x] `pmpro_after_checkout` fires → saved cart cleared from cookie + user meta
- [x] Logged-in user with user meta and no cookie → cookie hydrated from meta on next request
- [x] Admin settings form renders with the existing `pmpro_section` collapsible pattern, nonce-protected, saves correctly
- [ ] Manual browser walkthrough: popup → "Got it" → bar appears → click resume → checkout with discount/plan pre-filled
- [ ] Manual browser walkthrough: bar → X → styled confirm modal → "Hide" → bar gone for this cart token, "Cancel" → bar stays

## Notes for review

- Settings location: chose the existing Abandoned Cart Recovery admin page (new collapsible section above the recovery-attempts list table) rather than a new submenu, to keep the add-on's surface area tight. Happy to move it to a Settings tab if you'd prefer.
- The default copy is intentionally short and friendly: *"Take your time — we saved your spot. Keep browsing. Whenever you're ready to finish signing up, just tap the Resume Checkout bar at the bottom of the page."* All copy is overridable from the settings screen.
- Vanilla JS / no jQuery dependency to keep payload small and avoid coupling to PMPro's checkout JS.

## Update — theme-proof CSS (commit b1db05a)

Tested live on Memberlite 7.1.1 and caught a styling bug: secondary modal button rendered white-on-white on hover because Memberlite 7.x targets plain `button` selectors with its own background/color/box-shadow rules and swaps in `var(--wp--preset--color--buttons-hover)` on hover.

Fix:
- Scoped every selector under `#pmproacr-resume-root` to lift specificity above theme button rules.
- Explicitly set `background`, `color`, `box-shadow`, and `border-color` on every state (default, hover, focus, active) so nothing inherits from the active theme.
- Reset `font-family`, `text-shadow`, and `box-shadow` since Memberlite's base button styles change all three.
- Switched the secondary button from pure white to a light gray (`#f3f4f6` at rest, `#e5e7eb` on hover) so it stays visually distinct from the white modal background even if theme variables leak through.
